### PR TITLE
Add scraper and simple web UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+scraped_data/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fintech-Scraper
 
-Scrapes Investor materials from 
+Utilities for downloading investor materials from various Fintech companies.
 
 ---
 
@@ -54,3 +54,23 @@ Scrapes Investor materials from
 
 
 
+
+## Usage
+
+1. Run the scraper to download investor materials:
+
+```bash
+python3 scraper.py
+```
+
+This creates a `scraped_data/` directory with one subfolder per company. Run the script periodically (e.g. using cron) or invoke `schedule_daily()` to keep the data up to date.
+
+2. Start the web UI:
+
+```bash
+uvicorn app:app --reload --port 8000
+```
+
+Open `http://localhost:8000/` in a browser to browse available companies and their files. Market data for public tickers is fetched from Yahoo Finance.
+
+Note: the `push_to_chatgpt` function in `scraper.py` is a placeholder for pushing downloaded files to a custom ChatGPT instance.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import List
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "scraped_data")
+TRACK_FILE = "downloaded.json"
+
+app = FastAPI(title="Fintech Investor Materials")
+app.mount("/data", StaticFiles(directory=DATA_DIR), name="data")
+
+
+def list_companies() -> List[str]:
+    if not os.path.exists(DATA_DIR):
+        return []
+    return sorted(d for d in os.listdir(DATA_DIR) if os.path.isdir(os.path.join(DATA_DIR, d)))
+
+
+def load_history(company: str) -> dict:
+    path = os.path.join(DATA_DIR, company, TRACK_FILE)
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
+def fetch_market_data(ticker: str) -> dict | None:
+    if not ticker:
+        return None
+    url = f"https://query1.finance.yahoo.com/v7/finance/quote?symbols={ticker}"
+    try:
+        import urllib.request
+        with urllib.request.urlopen(url) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+        quote = data.get("quoteResponse", {}).get("result", [])
+        if quote:
+            q = quote[0]
+            return {
+                "price": q.get("regularMarketPrice"),
+                "marketCap": q.get("marketCap"),
+                "currency": q.get("currency"),
+            }
+    except Exception as e:
+        print(f"Failed market data for {ticker}: {e}")
+    return None
+
+
+@app.get("/", response_class=HTMLResponse)
+def index():
+    companies = list_companies()
+    items = "".join(
+        f'<li><a href="/{c}">{c.replace("_", " ").title()}</a></li>' for c in companies
+    )
+    html = f"""
+    <html>
+    <body>
+    <h1>Fintech Companies</h1>
+    <ul>{items}</ul>
+    </body>
+    </html>
+    """
+    return HTMLResponse(html)
+
+
+@app.get("/{company}", response_class=HTMLResponse)
+def company_page(company: str):
+    history = load_history(company)
+    if history is None:
+        raise HTTPException(status_code=404, detail="Company not found")
+    files = [history[url] for url in history]
+    files.sort()
+    ticker = None
+    meta_path = os.path.join(DATA_DIR, company, "metadata.json")
+    if os.path.exists(meta_path):
+        with open(meta_path, "r", encoding="utf-8") as f:
+            meta = json.load(f)
+            ticker = meta.get("ticker")
+    stats = fetch_market_data(ticker) if ticker else None
+    rows = "".join(f"<li><a href='/data/{company}/{f}'>{f}</a></li>" for f in files)
+    stats_html = ""
+    if stats:
+        stats_html = (
+            f"<p>Price: {stats['price']} {stats['currency']}<br>"
+            f"Market Cap: {stats['marketCap']}</p>"
+        )
+    html = f"""
+    <html><body>
+    <h1>{company.replace('_',' ').title()}</h1>
+    {stats_html}
+    <ul>{rows}</ul>
+    </body></html>
+    """
+    return HTMLResponse(html)

--- a/scraper.py
+++ b/scraper.py
@@ -1,0 +1,263 @@
+# coding: utf-8
+"""Scraper for Fintech investor materials.
+
+Downloads investor materials for all listed companies
+and stores them under scraped_data/<company>.
+Tracks downloaded URLs to avoid duplicates.
+
+This script uses only the Python standard library.
+"""
+
+from __future__ import annotations
+
+import os
+import json
+import time
+import urllib.request
+from html.parser import HTMLParser
+from urllib.parse import urljoin, urlparse
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "scraped_data")
+TRACK_FILE = "downloaded.json"
+
+COMPANIES = [
+    {
+        "name": "Dave Inc.",
+        "ticker": "DAVE",
+        "ir": "https://investors.dave.com/",
+    },
+    {
+        "name": "SoFi Technologies",
+        "ticker": "SOFI",
+        "ir": "https://investors.sofi.com/",
+    },
+    {
+        "name": "Upstart Holdings",
+        "ticker": "UPST",
+        "ir": "https://ir.upstart.com/",
+    },
+    {
+        "name": "LendingClub Corp.",
+        "ticker": "LC",
+        "ir": "https://ir.lendingclub.com/",
+    },
+    {
+        "name": "Affirm Holdings",
+        "ticker": "AFRM",
+        "ir": "https://investors.affirm.com/",
+    },
+    {
+        "name": "Block Inc.",
+        "ticker": "SQ",
+        "ir": "https://investors.block.xyz/",
+    },
+    {
+        "name": "PayPal Holdings",
+        "ticker": "PYPL",
+        "ir": "https://investor.pypl.com/",
+    },
+    {
+        "name": "Robinhood Markets",
+        "ticker": "HOOD",
+        "ir": "https://investors.robinhood.com/",
+    },
+    {
+        "name": "Coinbase Global",
+        "ticker": "COIN",
+        "ir": "https://investor.coinbase.com/",
+    },
+    {
+        "name": "Varo Bank",
+        "ticker": None,
+        "ir": "https://www.varomoney.com",
+    },
+    {
+        "name": "Chime",
+        "ticker": None,
+        "ir": "https://www.chime.com",
+    },
+    {
+        "name": "Stripe",
+        "ticker": None,
+        "ir": "https://stripe.com",
+    },
+    {
+        "name": "Brex",
+        "ticker": None,
+        "ir": "https://www.brex.com",
+    },
+    {
+        "name": "Plaid",
+        "ticker": None,
+        "ir": "https://plaid.com",
+    },
+    {
+        "name": "Marqeta",
+        "ticker": "MQ",
+        "ir": "https://investors.marqeta.com/",
+    },
+    {
+        "name": "Ramp",
+        "ticker": None,
+        "ir": "https://ramp.com",
+    },
+    {
+        "name": "Current",
+        "ticker": None,
+        "ir": "https://current.com",
+    },
+    {
+        "name": "Upgrade",
+        "ticker": None,
+        "ir": "https://upgrade.com",
+    },
+    {
+        "name": "Adyen",
+        "ticker": "ADYEN",
+        "ir": "https://investors.adyen.com/",
+    },
+    {
+        "name": "Nu Holdings (Nubank)",
+        "ticker": "NU",
+        "ir": "https://investors.nu/",
+    },
+    {
+        "name": "Wise plc",
+        "ticker": "WISE",
+        "ir": "https://wise.com/investors",
+    },
+    {
+        "name": "Revolut",
+        "ticker": None,
+        "ir": "https://www.revolut.com",
+    },
+    {
+        "name": "Monzo",
+        "ticker": None,
+        "ir": "https://monzo.com",
+    },
+    {
+        "name": "Starling Bank",
+        "ticker": None,
+        "ir": "https://www.starlingbank.com",
+    },
+    {
+        "name": "N26",
+        "ticker": None,
+        "ir": "https://n26.com",
+    },
+]
+
+
+class LinkParser(HTMLParser):
+    """Minimal HTML parser to extract links to likely investor files."""
+
+    def __init__(self):
+        super().__init__()
+        self.links = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag != "a":
+            return
+        href = None
+        for attr, val in attrs:
+            if attr == "href":
+                href = val
+                break
+        if href and any(href.lower().endswith(ext) for ext in [
+            ".pdf", ".zip", ".ppt", ".pptx", ".xls", ".xlsx"
+        ]):
+            self.links.append(href)
+
+
+def ensure_dir(path: str) -> None:
+    if not os.path.exists(path):
+        os.makedirs(path)
+
+
+def load_history(company_dir: str) -> dict:
+    track_path = os.path.join(company_dir, TRACK_FILE)
+    if os.path.exists(track_path):
+        with open(track_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
+def save_history(company_dir: str, history: dict) -> None:
+    track_path = os.path.join(company_dir, TRACK_FILE)
+    with open(track_path, "w", encoding="utf-8") as f:
+        json.dump(history, f, indent=2)
+
+
+def download_file(url: str, dest: str) -> None:
+    with urllib.request.urlopen(url) as resp, open(dest, "wb") as out:
+        out.write(resp.read())
+
+
+def push_to_chatgpt(path: str) -> None:
+    """Placeholder for pushing files to custom ChatGPT."""
+    print(f"[CHATGPT] Would push {path}")
+
+
+def scrape_company(company: dict) -> None:
+    name = company["name"]
+    ir_url = company["ir"]
+    print(f"Scraping {name}: {ir_url}")
+    company_slug = name.lower().replace(" ", "_")
+    company_dir = os.path.join(DATA_DIR, company_slug)
+    ensure_dir(company_dir)
+    # store metadata with ticker so UI can show market stats
+    meta_path = os.path.join(company_dir, "metadata.json")
+    meta = {"name": name, "ticker": company.get("ticker")}
+    with open(meta_path, "w", encoding="utf-8") as f:
+        json.dump(meta, f)
+    history = load_history(company_dir)
+
+    try:
+        with urllib.request.urlopen(ir_url) as resp:
+            html = resp.read().decode("utf-8", errors="ignore")
+    except Exception as e:
+        print(f"Failed to download {ir_url}: {e}")
+        return
+
+    parser = LinkParser()
+    parser.feed(html)
+
+    new_links = []
+    for link in parser.links:
+        abs_url = urljoin(ir_url, link)
+        if abs_url in history:
+            continue
+        filename = os.path.basename(urlparse(abs_url).path)
+        if not filename:
+            continue
+        dest_path = os.path.join(company_dir, filename)
+        try:
+            print(f"  downloading {abs_url}")
+            download_file(abs_url, dest_path)
+            history[abs_url] = filename
+            new_links.append(dest_path)
+        except Exception as e:
+            print(f"  failed {abs_url}: {e}")
+
+    if new_links:
+        save_history(company_dir, history)
+        for path in new_links:
+            push_to_chatgpt(path)
+
+
+def scrape_all() -> None:
+    ensure_dir(DATA_DIR)
+    for company in COMPANIES:
+        scrape_company(company)
+
+
+def schedule_daily() -> None:
+    while True:
+        scrape_all()
+        print("Sleeping for 24h...")
+        time.sleep(60 * 60 * 24)
+
+
+if __name__ == "__main__":
+    scrape_all()


### PR DESCRIPTION
## Summary
- add Python-based scraper for investor materials
- create minimal FastAPI UI to browse downloaded files
- save company metadata for market data lookup
- document usage instructions
- ignore scraped data in git

## Testing
- `python3 -m py_compile scraper.py app.py`