### PR TITLE
Add user agent to avoid 403 errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,7 @@ uvicorn app:app --reload --port 8000
 Open `http://localhost:8000/` in a browser to browse available companies and their files. Market data for public tickers is fetched from Yahoo Finance.
 
 Note: the `push_to_chatgpt` function in `scraper.py` is a placeholder for pushing downloaded files to a custom ChatGPT instance.
+
+## Troubleshooting
+
+If you receive HTTP 403 errors when running the scraper, some sites may block requests without a browser-like user agent. The tool includes a default `User-Agent` header, but you can edit `USER_AGENT` in `scraper.py` if downloads continue to fail.

--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
+USER_AGENT = "Mozilla/5.0 (FintechScraper/1.0)"
 DATA_DIR = os.path.join(os.path.dirname(__file__), "scraped_data")
 TRACK_FILE = "downloaded.json"
 
@@ -35,7 +36,8 @@ def fetch_market_data(ticker: str) -> dict | None:
     url = f"https://query1.finance.yahoo.com/v7/finance/quote?symbols={ticker}"
     try:
         import urllib.request
-        with urllib.request.urlopen(url) as resp:
+        req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+        with urllib.request.urlopen(req) as resp:
             data = json.loads(resp.read().decode("utf-8"))
         quote = data.get("quoteResponse", {}).get("result", [])
         if quote:

--- a/scraper.py
+++ b/scraper.py
@@ -16,6 +16,9 @@ import time
 import urllib.request
 from html.parser import HTMLParser
 from urllib.parse import urljoin, urlparse
+USER_AGENT = "Mozilla/5.0 (FintechScraper/1.0)"
+HEADERS = {"User-Agent": USER_AGENT}
+
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "scraped_data")
 TRACK_FILE = "downloaded.json"
@@ -190,7 +193,8 @@ def save_history(company_dir: str, history: dict) -> None:
 
 
 def download_file(url: str, dest: str) -> None:
-    with urllib.request.urlopen(url) as resp, open(dest, "wb") as out:
+    req = urllib.request.Request(url, headers=HEADERS)
+    with urllib.request.urlopen(req) as resp, open(dest, "wb") as out:
         out.write(resp.read())
 
 
@@ -214,7 +218,8 @@ def scrape_company(company: dict) -> None:
     history = load_history(company_dir)
 
     try:
-        with urllib.request.urlopen(ir_url) as resp:
+        req = urllib.request.Request(ir_url, headers=HEADERS)
+        with urllib.request.urlopen(req) as resp:
             html = resp.read().decode("utf-8", errors="ignore")
     except Exception as e:
         print(f"Failed to download {ir_url}: {e}")


### PR DESCRIPTION
## Summary
- set a `USER_AGENT` constant for `scraper.py` and `app.py`
- use the header in web requests
- document the 403 fix in README

## Testing
- `python3 -m py_compile scraper.py app.py`